### PR TITLE
Disable close menu after upadting Enabled tickbox, Fixes #180

### DIFF
--- a/ui/configure-for-current-tab-panel.js
+++ b/ui/configure-for-current-tab-panel.js
@@ -98,7 +98,7 @@
     let checkbox = document.createElement('input');
     checkbox.setAttribute('type', 'checkbox');
     checkbox.checked = enabled;
-    checkbox.onchange = () => { set_pref('enabled', checkbox.checked); close(); };
+    checkbox.onchange = () => { set_pref('enabled', checkbox.checked); };
     checkbox_label.appendChild(checkbox);
     body.appendChild(checkbox_label);
 


### PR DESCRIPTION
This fixes the issue of not updating the `enabled` value when clicking tickbox