### PR TITLE
Tweak default colors (softer white/black)

### DIFF
--- a/lib/shared.js
+++ b/lib/shared.js
@@ -72,37 +72,37 @@ const preferences = [
     {
         type: 'color',
         name: 'default_foreground_color',
-        value: '#ffffff',
+        value: '#f7f7f7',
         title: 'Default foreground color',
     },
     {
         type: 'color',
         name: 'default_background_color',
-        value: '#000000',
+        value: '#111111',
         title: 'Default background color',
     },
     {
         type: 'color',
         name: 'default_link_color',
-        value: '#7fd7ff',
+        value: '#7777ee',
         title: 'Default link color',
     },
     {
         type: 'color',
         name: 'default_visited_color',
-        value: '#ffafff',
+        value: '#ffaff663e8bf',
         title: 'Default visited link color',
     },
     {
         type: 'color',
         name: 'default_active_color',
-        value: '#ff0000',
+        value: '#ff3333',
         title: 'Default active link color',
     },
     {
         type: 'color',
         name: 'default_selection_color',
-        value: '#8080ff',
+        value: '#ffd38c',
         title: 'Default selection color',
     },
     {


### PR DESCRIPTION
People may uninstall before they try to change the defaults. #ffffff and #000000 are too harsh for most users.