### PR TITLE
Optimizatons for speed and memory use - base.css

### DIFF
--- a/methods/base.css
+++ b/methods/base.css
@@ -10,16 +10,11 @@
 }
 
 html, page, window {
-{if_toplevel_start}
-  background-color: #{default_background_color};
-{if_toplevel_end}
-  color: #{default_foreground_color};
+  {if_toplevel_start}
+    background-color: #{default_background_color};
+  {if_toplevel_end}
+    color: #{default_foreground_color};
   /* background-image: none !important; */
-}
-
-* {
-  /* color: #{default_foreground_color}; */
-  /*background-color: black; <- do not set it here*/
 }
 
 *:link, *:link * {
@@ -30,8 +25,7 @@ html, page, window {
     color: #{default_visited_color} !important;
 }
 
-input[type="range"]
-{
+input[type="range"] {
     -moz-appearance: none;
 }
 
@@ -39,8 +33,7 @@ button,
 input:not([type="checkbox"]):not([type="radio"]):not([type="range"]):not([type="file"]),
 textarea,
 select,
-[contenteditable="true"]
-{
+[contenteditable="true"] {
     -moz-appearance: none !important;
     color: #{default_foreground_color} !important;
     background-color: #{default_background_color};
@@ -94,7 +87,6 @@ select {
     background-size: 1em !important;
 }
 
-
 *::-moz-selection {
     color: #{default_foreground_color} !important;
     background: #{default_selection_color} !important;
@@ -108,7 +100,7 @@ select {
 }
 
 xul|*.checkbox-check[checked] {
-    /* modified version of chrome://global/skin/in-content/check.svg */
+    /* based on chrome://global/skin/icons/check.svg */
     list-style-image: url('data:image/svg+xml;utf8,<?xml version="1.0" encoding="utf-8"?><svg xmlns="http://www.w3.org/2000/svg" width="21" height="21"><path fill="%23{default_foreground_color}" d="M 9.39,16.5 16.28,6 14.77,4.5 9.37,12.7 6.28,9.2 4.7,10.7 z"/></svg>') !important;
 }
 xul|*.radio-check[selected] {
@@ -120,15 +112,13 @@ xul|menulist:not([editable="true"]) > xul|*.menulist-dropmarker {
     list-style-image: url('data:image/svg+xml;utf8,<?xml version="1.0" encoding="utf-8"?><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path xmlns="http://www.w3.org/2000/svg" fill="%23{default_foreground_color}" d="M12,6l-4.016,4L4,6H12z"/></svg>') !important;
 }
 
-/* https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XUL/Tutorial/Styling_a_Tree */
-/* #27 */
+/* #27 https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XUL/Tutorial/Styling_a_Tree */
 treechildren {
     background-color: #{default_background_color} !important;
 }
 treechildren::-moz-tree-cell,
 treechildren::-moz-tree-row,
-treechildren::-moz-tree-row(odd)
-{
+treechildren::-moz-tree-row(odd) {
     background-color: transparent !important;
 }
 treechildren::-moz-tree-cell-text {
@@ -141,52 +131,45 @@ treechildren::-moz-tree-row(selected) {
     background: #{default_selection_color} !important;
 }
 
-
 /* TODO: "black on transparent" mark */
 img[alt="inline_formula"],
-.mwe-math-fallback-image-inline,
-.highcharts-container /* charts, for example on https://addons.mozilla.org/en-US/firefox/addon/black-background-white-text/statistics/ */
-{
-    {if_dark_background_start}
-    filter: invert(100%) hue-rotate(180deg) !important;
-    {if_dark_background_end}
+.mwe-math-fallback-image-inline {
+  {if_dark_background_start}
+    filter: invert(1) hue-rotate(180deg) !important;
+  {if_dark_background_end}
 }
 
-groupbox#dialogBox { /* about:preferences dialogs */
-    box-shadow: 0 0 4px 3px #{default_foreground_color} !important;
-}
-
-/*Google Hangouts fixes*/
-@-moz-document url-prefix("https://talkgadget.google.com/")
-{
+/* Google Hangouts */
+@-moz-document url-prefix("https://talkgadget.google.com/") {
     div.PD.IF, img.Yf {
         border: 1pt solid #{default_foreground_color} !important;
     }
-
     div.ci {
         visibility: hidden !important;
     }
 }
+
 {if_dark_background_start}
 @-moz-document url-prefix("http://catalog.onliner.by/") {
     .i-checkbox__faux::before {
-        filter: invert(100%);
+        filter: invert(1);
     }
 }
 {if_dark_background_end}
-/* google scholar bars on right sidebar fix #8 */
+
+/* Google Scholar bars on right sidebar #8 */
 @-moz-document url-prefix("https://scholar.google.") {
     #gsc_g_bars .gsc_g_a[style*="height"] {
         background-color: rgb(119, 119, 119) !important;
     }
 }
 
-/* youtube annotations backgrounds #32 */
+/* #32 YouTube annotation backgrounds */
 @-moz-document domain('youtube.com') {
     /* document.querySelectorAll('.annotation-shape svg path').forEach(node => { let color = node.getAttribute('fill'); console.log(`.video-annotations .annotation-shape svg path[fill="${color}"] { fill: ${color} !important; }`)}) */
     /* TODO: proportional color change */
     /* TODO: less hardcode */
-    {if_dark_background_start}
+  {if_dark_background_start}
     .video-annotations .annotation-shape svg path[fill="#fdda36"] { fill: #664627 !important; }
     .video-annotations .annotation-shape svg path[fill="#fcc228"] { fill: #664b14 !important; }
     .video-annotations .annotation-shape svg path[fill="#ffe673"] { fill: #685b2e !important; }
@@ -220,10 +203,10 @@ groupbox#dialogBox { /* about:preferences dialogs */
     .video-annotations .annotation-shape svg path[fill="#7c54ae"] { fill: #7c54ae !important; }
     .video-annotations .annotation-shape svg path[fill="#afecd1"] { fill: #4d6758 !important; }
     .video-annotations .annotation-shape svg path[fill="#403e9a"] { fill: #403e9a !important; }
-    {if_dark_background_end}
+  {if_dark_background_end}
 }
 
-/* https://github.com/qooob/authentic-theme radio buttons. unfortunately, there is no public available demo */
+/* https://github.com/qooob/authentic-theme radio buttons -no public demo */
 .awradio label::after {
     background-color: #{default_foreground_color} !important;
 }
@@ -236,18 +219,9 @@ groupbox#dialogBox { /* about:preferences dialogs */
     }
 }
 
-@-moz-document domain('addons.mozilla.org') {
-    {if_dark_background_start}
-    .stars label[data-stars] {
-        background-repeat: no-repeat;
-        background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAALCAYAAACprHcmAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAmElEQVQY03XQXWoCQRAE4M8fNO+CQfzBI+QKPoQcWXKLBLyBiIIXcBekfemFdRwLhqKL6pqZEhEqZ1fTh16xwkfyE2rmNSbJTxgnT3varMd9vRlExHchwgj3QmsGEQE/+aSJOm747czwhUWx0OKMf0T/g6c3qVdE2cYyU++Z2Oa8qVX3mYYL9nl9i3lZXbd4xCHnPzTYdoYHwrRCbdd8fYkAAAAASUVORK5CYII=') !important;
-    }
-    {if_dark_background_end}
-}
-
-/* buttons on many google services (Books, Translate, etc) */
+/* buttons on many Google services (Books, Translate, etc) */
 {if_dark_background_start}
-.jfk-button-img {
-    filter: invert(100%);
+    .jfk-button-img {
+        filter: invert(1);
 }
 {if_dark_background_end}


### PR DESCRIPTION
This code is injected, so must be optimized for speed and memory use.

Optimizations in this pull request:
   1. Change invert(100%) to invert(1) to prevent browser from having to calculate the conversion.
   1. Remove about:preferences styles - about:* is no longer accessible to extensions (without non-recommended tweaks).
   1. Remove AMO styles - AMO is no longer accessible to extensions (without non-recommended tweaks).
   1. Reduce length of comment strings.
   1. Corrected internal chrome url reference.
   1. Improve formatting.