### PR TITLE
Optimizatons for speed and memory use - invert.css

### DIFF
--- a/methods/invert.css
+++ b/methods/invert.css
@@ -1,4 +1,4 @@
-@supports (backdrop-filter: invert(100%)) {
+@supports (backdrop-filter: invert(1)) {
     #mybpwaycfxccmnp-dblt-backdrop-filter {
         display: block !important;
         position: fixed !important;
@@ -9,27 +9,26 @@
         margin: 0 !important;
         pointer-events: none !important;
         z-index: 2147483647 !important;
-        backdrop-filter: invert(100%) hue-rotate(180deg) !important;
+        backdrop-filter: invert(1) hue-rotate(180deg) !important;
     }
     img:not(.mwe-math-fallback-image-inline):not([alt="inline_formula"]),
     video {
-        filter: invert(100%) hue-rotate(180deg) !important;
+        filter: invert(1) hue-rotate(180deg) !important;
     }
 }
 @supports not (backdrop-filter: invert(100%)) {
     html,
-    img:not(.mwe-math-fallback-image-inline):not([alt="inline_formula"]),    /* TODO: "black on transparent" mark */
+    img:not(.mwe-math-fallback-image-inline):not([alt="inline_formula"]),  /* TODO: "black on transparent" mark */
     embed[type="application/x-shockwave-flash"],
     object[type="application/x-shockwave-flash"],
     video,
-    div#viewer.pdfViewer div.page
-    {
-        filter: invert(100%) hue-rotate(180deg) !important;
+    div#viewer.pdfViewer div.page {
+        filter: invert(1) hue-rotate(180deg) !important;
     }
+
     /* #28 */
     :fullscreen video,
-    video:fullscreen
-    {
+    video:fullscreen {
         filter: none !important;
     }
 


### PR DESCRIPTION
This code is injected, so must be optimized for speed and memory use.

Optimizations in this pull request:

    1. Change invert(100%) to invert(1) to prevent browser from having to calculate the conversion.
    2. Improve formatting.