### PR TITLE
Simple attempt to fix #304

### DIFF
--- a/src/browser-action/index.ts
+++ b/src/browser-action/index.ts
@@ -98,6 +98,7 @@ declare const browser: Browser;
     }
     const isPrivate = current_tab.incognito;
     const enabled = await get_prefs('enabled');
+    const night_enabled = await get_prefs('night_enabled');
     const body = document.querySelector('body')!;
     if ((await browser.runtime.getPlatformInfo()).os === 'android') {
         body.setAttribute('class', 'touchscreen');
@@ -161,15 +162,28 @@ declare const browser: Browser;
         close();
     }
 
-    const checkbox_label = document.createElement('label');
-    checkbox_label.setAttribute('class', 'enabled_label');
-    checkbox_label.textContent = 'Enabled';
-    const checkbox = document.createElement('input');
-    checkbox.setAttribute('type', 'checkbox');
-    checkbox.checked = enabled;
-    checkbox.onchange = () => { set_pref('enabled', checkbox.checked).then(() => close()); };
-    checkbox_label.appendChild(checkbox);
-    body.appendChild(checkbox_label);
+    const enabled_checkbox_label = document.createElement('label');
+    enabled_checkbox_label.setAttribute('class', 'enabled_label');
+    enabled_checkbox_label.textContent = 'Enabled';
+    const enabled_checkbox = document.createElement('input');
+    enabled_checkbox.setAttribute('type', 'checkbox');
+    enabled_checkbox.checked = enabled;
+    enabled_checkbox.onchange = () => { set_pref('enabled', enabled_checkbox.checked).then(() => close()); };
+    enabled_checkbox_label.appendChild(enabled_checkbox);
+    body.appendChild(enabled_checkbox_label);
+
+    const night_checkbox_label = document.createElement('label');
+    night_checkbox_label.setAttribute('class', 'enabled_label');
+    night_checkbox_label.textContent = 'Night time only';
+    const night_checkbox = document.createElement('input');
+    night_checkbox.setAttribute('type', 'checkbox');
+    night_checkbox.checked = night_enabled;
+    if(!enabled) {
+        night_checkbox.disabled = true;
+    }
+    night_checkbox.onchange = () => { set_pref('night_enabled', night_checkbox.checked).then(() => close()); };
+    night_checkbox_label.appendChild(night_checkbox);
+    body.appendChild(night_checkbox_label);
 
     body.appendChild(document.createElement('hr'));
 

--- a/src/browser-action/index.ts
+++ b/src/browser-action/index.ts
@@ -8,7 +8,7 @@ import {
 import { methods } from '../methods/methods';
 import { hint_marker } from '../common/generate-urls';
 import { smart_generate_urls } from '../common/smart-generate-urls';
-import { ActivationMode, ConfiguredPages } from '../common/types';
+import { EnablePolicy, ConfiguredPages } from '../common/types';
 import '../common/ui-style';
 
 declare const browser: Browser;
@@ -97,7 +97,7 @@ declare const browser: Browser;
         preselect = CURRENT_TAB_LABEL;
     }
     const isPrivate = current_tab.incognito;
-    const activation = await get_prefs('activation');
+    const enable_policy = await get_prefs('enable_policy');
     const body = document.querySelector('body')!;
     if ((await browser.runtime.getPlatformInfo()).os === 'android') {
         body.setAttribute('class', 'touchscreen');
@@ -161,27 +161,27 @@ declare const browser: Browser;
         close();
     }
 
-    const activation_select_label = document.createElement('label');
-    activation_select_label.setAttribute('class', 'activation_label');
-    activation_select_label.textContent = 'Mode';
-    const activation_select = document.createElement('select');
-    Object.entries(ActivationMode).forEach(([key, value]) => {
+    const enable_policy_select_label = document.createElement('label');
+    enable_policy_select_label.setAttribute('class', 'enable_policy_label');
+    enable_policy_select_label.textContent = 'Mode';
+    const enable_policy_select = document.createElement('select');
+    Object.entries(EnablePolicy).forEach(([key, value]) => {
         const mode_option = document.createElement('option');
         mode_option.value = value;
         mode_option.text = key;
-        mode_option.selected = value === activation;
-        activation_select.appendChild(mode_option);
+        mode_option.selected = value === enable_policy;
+        enable_policy_select.appendChild(mode_option);
     });
-    activation_select.onchange = (e) => {
+    enable_policy_select.onchange = (e) => {
         if (!e.target) { return; }
 
         const select_target = e.target as HTMLSelectElement;
         if (!select_target) { return; }
 
-        set_pref('activation', select_target.value).then(() => close());
+        set_pref('enable_policy', select_target.value).then(() => close());
     };
-    activation_select_label.appendChild(activation_select);
-    body.appendChild(activation_select_label);
+    enable_policy_select_label.appendChild(enable_policy_select);
+    body.appendChild(enable_policy_select_label);
 
     body.appendChild(document.createElement('hr'));
 
@@ -189,7 +189,7 @@ declare const browser: Browser;
     container.setAttribute('class', 'page_settings_container');
     container.style.position = 'relative';
 
-    if (activation === ActivationMode.Off) {
+    if (enable_policy === EnablePolicy.Off) {
         const overlay = document.createElement('div');
         overlay.setAttribute('class', 'disabled_overlay');
         container.appendChild(overlay);

--- a/src/common/shared.ts
+++ b/src/common/shared.ts
@@ -21,6 +21,12 @@ export const preferences: Preferences = [
         title: 'Enabled',
     } as BoolPreference,
     {
+        type: 'bool',
+        name: 'night_enabled',
+        value: false,
+        title: 'Night time enabled only',
+    } as BoolPreference,
+    {
         title: 'Default method of changing page colors',
         value: 1,
         type: 'menulist',
@@ -91,6 +97,7 @@ export const prefs_keys_with_defaults = ((): PrefsWithValues => {
 
 export function get_prefs(prefs?: string[]): Promise<PrefsWithValues>;
 export function get_prefs(prefs: 'enabled'): Promise<boolean>;
+export function get_prefs(prefs: 'night_enabled'): Promise<boolean>;
 export function get_prefs(prefs: 'configured_pages'): Promise<ConfiguredPages>;
 export function get_prefs(prefs: 'default_method'): Promise<MethodIndex>;
 export function get_prefs(prefs: 'do_not_set_overrideDocumentColors_to_never'): Promise<boolean>;

--- a/src/common/shared.ts
+++ b/src/common/shared.ts
@@ -8,27 +8,27 @@ import type {
     MenuListPreference,
     ColorPreference,
     ConfiguredPagesPreference,
+    ActivationModeType,
 } from './types';
-import { methods } from '../methods/methods';
+import { ActivationMode } from './types';
+import { methods, STYLESHEET_PROCESSOR_ID } from '../methods/methods';
 
 declare const browser: Browser;
 
 export const preferences: Preferences = [
     {
-        type: 'bool',
-        name: 'enabled',
-        value: true,
-        title: 'Enabled',
-    } as BoolPreference,
-    {
-        type: 'bool',
-        name: 'night_enabled',
-        value: false,
-        title: 'Night time enabled only',
-    } as BoolPreference,
+        title: 'Enable, disable extension or switch off based on time or system theme',
+        value: ActivationMode.On,
+        type: 'menulist',
+        options: Object.entries(ActivationMode).map(([key, value]) => ({
+            label: key,
+            value,
+        })),
+        name: 'activation',
+    } as MenuListPreference,
     {
         title: 'Default method of changing page colors',
-        value: 1,
+        value: STYLESHEET_PROCESSOR_ID,
         type: 'menulist',
         options: Object.keys(methods).filter((key) => (parseInt(key, 10) >= 0)).map((key) => ({
             label: methods[key].label,
@@ -95,9 +95,8 @@ export const prefs_keys_with_defaults = ((): PrefsWithValues => {
     return result;
 })();
 
+export function get_prefs(prefs: 'activation'): Promise<ActivationModeType>;
 export function get_prefs(prefs?: string[]): Promise<PrefsWithValues>;
-export function get_prefs(prefs: 'enabled'): Promise<boolean>;
-export function get_prefs(prefs: 'night_enabled'): Promise<boolean>;
 export function get_prefs(prefs: 'configured_pages'): Promise<ConfiguredPages>;
 export function get_prefs(prefs: 'default_method'): Promise<MethodIndex>;
 export function get_prefs(prefs: 'do_not_set_overrideDocumentColors_to_never'): Promise<boolean>;
@@ -130,7 +129,8 @@ export function set_pref(pref: string, value: PrefsType): Promise<void> {
     }
 }
 
-export function on_prefs_change(callback: (changes: {[s: string]: Storage.StorageChange}) => void) {
+export function on_prefs_change(callback:
+    (changes: { [s: string]: Storage.StorageChange }) => void) {
     browser.storage.onChanged.addListener((changes, areaName) => {
         if (areaName !== 'local') {
             throw new Error('unsupported');

--- a/src/common/shared.ts
+++ b/src/common/shared.ts
@@ -8,9 +8,9 @@ import type {
     MenuListPreference,
     ColorPreference,
     ConfiguredPagesPreference,
-    ActivationModeType,
+    EnablePolicyType,
 } from './types';
-import { ActivationMode } from './types';
+import { EnablePolicy } from './types';
 import { methods, STYLESHEET_PROCESSOR_ID } from '../methods/methods';
 
 declare const browser: Browser;
@@ -18,13 +18,13 @@ declare const browser: Browser;
 export const preferences: Preferences = [
     {
         title: 'Enable, disable extension or switch off based on time or system theme',
-        value: ActivationMode.On,
+        value: EnablePolicy.On,
         type: 'menulist',
-        options: Object.entries(ActivationMode).map(([key, value]) => ({
+        options: Object.entries(EnablePolicy).map(([key, value]) => ({
             label: key,
             value,
         })),
-        name: 'activation',
+        name: 'enable_policy',
     } as MenuListPreference,
     {
         title: 'Default method of changing page colors',
@@ -95,7 +95,7 @@ export const prefs_keys_with_defaults = ((): PrefsWithValues => {
     return result;
 })();
 
-export function get_prefs(prefs: 'activation'): Promise<ActivationModeType>;
+export function get_prefs(prefs: 'enable_policy'): Promise<EnablePolicyType>;
 export function get_prefs(prefs?: string[]): Promise<PrefsWithValues>;
 export function get_prefs(prefs: 'configured_pages'): Promise<ConfiguredPages>;
 export function get_prefs(prefs: 'default_method'): Promise<MethodIndex>;

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -21,6 +21,7 @@ export interface ConfiguredTabs {
 }
 export interface AddonOptions {
     enabled: boolean,
+    night_enabled: boolean,
     global_toggle_hotkey: string,
     tab_toggle_hotkey: string,
     default_method: MethodIndex,

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -23,7 +23,6 @@ export interface ConfiguredTabs {
 export const ActivationMode = {
     Off: 'off',
     On: 'on',
-    'Time (6 to 6)': 'time',
     'System Theme': 'system-theme',
 } as const;
 

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -20,16 +20,16 @@ export interface ConfiguredTabs {
     [key: number]: MethodIndex
 }
 
-export const ActivationMode = {
+export const EnablePolicy = {
     Off: 'off',
     On: 'on',
     'System Theme': 'system-theme',
 } as const;
 
-export type ActivationModeType = typeof ActivationMode[keyof (typeof ActivationMode)];
+export type EnablePolicyType = typeof EnablePolicy[keyof (typeof EnablePolicy)];
 
 export interface AddonOptions {
-    activation: ActivationModeType,
+    enable_policy: EnablePolicyType,
     global_toggle_hotkey: string,
     tab_toggle_hotkey: string,
     default_method: MethodIndex,

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -12,16 +12,25 @@ export interface RGB_obj {
     B: number,
 }
 
-export type MethodIndex = '-1'|'0'|'1'|'2'|'3'
+export type MethodIndex = '-1' | '0' | '1' | '2' | '3'
 export interface ConfiguredPages {
     [key: string]: MethodIndex
 }
 export interface ConfiguredTabs {
     [key: number]: MethodIndex
 }
+
+export const ActivationMode = {
+    Off: 'off',
+    On: 'on',
+    'Time (6 to 6)': 'time',
+    'System Theme': 'system-theme',
+} as const;
+
+export type ActivationModeType = typeof ActivationMode[keyof (typeof ActivationMode)];
+
 export interface AddonOptions {
-    enabled: boolean,
-    night_enabled: boolean,
+    activation: ActivationModeType,
     global_toggle_hotkey: string,
     tab_toggle_hotkey: string,
     default_method: MethodIndex,
@@ -34,12 +43,12 @@ export interface AddonOptions {
     do_not_set_overrideDocumentColors_to_never: boolean,
     configured_pages: ConfiguredPages,
 }
-export type PrefsType = string|number|boolean|ConfiguredPages
+export type PrefsType = string | number | boolean | ConfiguredPages
 interface Preference {
-    type: 'bool'|'menulist'|'color'|'configured_pages',
+    type: 'bool' | 'menulist' | 'color' | 'configured_pages',
     name: string,
     value: PrefsType,
-    options?: Array<{label: string, value: string}>,
+    options?: Array<{ label: string, value: string }>,
     title: string,
 }
 export interface BoolPreference extends Preference {
@@ -52,8 +61,8 @@ export interface BoolPreference extends Preference {
 export interface MenuListPreference extends Preference {
     type: 'menulist',
     name: string,
-    value: number,
-    options: Array<{label: string, value: string}>,
+    value: string,
+    options: Array<{ label: string, value: string }>,
     title: string,
 }
 export interface ColorPreference extends Preference {
@@ -71,7 +80,7 @@ export interface ConfiguredPagesPreference extends Preference {
     title: string,
 }
 export type Preferences = (
-  BoolPreference|MenuListPreference|ColorPreference|ConfiguredPagesPreference
+    BoolPreference | MenuListPreference | ColorPreference | ConfiguredPagesPreference
 )[];
 
 
@@ -109,10 +118,10 @@ export interface MethodExecutor {
     unload_from_window(): void;
 }
 export interface MethodExecutorStatic {
-    new (window: Window, options: AddonOptions): MethodExecutor;
+    new(window: Window, options: AddonOptions): MethodExecutor;
 }
 export interface MethodMetadataWithExecutors extends MethodMetadataBare {
-    executor: MethodExecutorStatic|null,
+    executor: MethodExecutorStatic | null,
 }
 export type MethodsMetadataBare = {
     [key: string /* MethodIndex */]: MethodMetadataBare

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -38,39 +38,39 @@ if (typeof window.content_script_state === 'undefined') { /* #226 part 1 workaro
 }
 
 async function get_method_for_url(url: string): Promise<MethodMetadataWithExecutors> {
-    if (window.prefs.enabled) {
-        if (is_iframe) {
-            const parent_method_number = await browser.runtime.sendMessage({ action: 'query_parent_method_number' });
-            if (methods[parent_method_number].affects_iframes) {
-                return methods[0];
-            } else if (url === 'about:blank' || url === 'about:srcdoc') {
-                return methods[parent_method_number];
-            }
-        }
-        // TODO: get rid of await here, https://bugzilla.mozilla.org/show_bug.cgi?id=1574713
-        let tab_configuration: MethodIndex | boolean = false;
-        if (Object.keys(window.configured_tabs).length > 0) {
-            const tabId = await tabId_promise;
-            tab_configuration = (
-                Object.prototype.hasOwnProperty.call(window.configured_tabs, tabId)
-                    ? window.configured_tabs[tabId]
-                    : false
-            );
-        }
-        if (tab_configuration !== false) {
-            return methods[tab_configuration];
-        }
-
-        const configured_urls = Object.keys(window.merged_configured);
-        for (const gen_url of generate_urls(url)) {
-            if (configured_urls.indexOf(gen_url) >= 0) {
-                return methods[window.merged_configured[gen_url]];
-            }
-        }
-        return methods[window.prefs.default_method];
-    } else {
+    if(!window.prefs.enabled) {
         return methods[0];
     }
+
+    if (is_iframe) {
+        const parent_method_number = await browser.runtime.sendMessage({ action: 'query_parent_method_number' });
+        if (methods[parent_method_number].affects_iframes) {
+            return methods[0];
+        } else if (url === 'about:blank' || url === 'about:srcdoc') {
+            return methods[parent_method_number];
+        }
+    }
+    // TODO: get rid of await here, https://bugzilla.mozilla.org/show_bug.cgi?id=1574713
+    let tab_configuration: MethodIndex | boolean = false;
+    if (Object.keys(window.configured_tabs).length > 0) {
+        const tabId = await tabId_promise;
+        tab_configuration = (
+            Object.prototype.hasOwnProperty.call(window.configured_tabs, tabId)
+                ? window.configured_tabs[tabId]
+                : false
+        );
+    }
+    if (tab_configuration !== false) {
+        return methods[tab_configuration];
+    }
+
+    const configured_urls = Object.keys(window.merged_configured);
+    for (const gen_url of generate_urls(url)) {
+        if (configured_urls.indexOf(gen_url) >= 0) {
+            return methods[window.merged_configured[gen_url]];
+        }
+    }
+    return methods[window.prefs.default_method];
 }
 
 let current_method: MethodMetadataWithExecutors;

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -6,7 +6,7 @@ import {
     MethodIndex,
     MethodExecutor,
     MethodMetadataWithExecutors,
-    ActivationMode,
+    EnablePolicy,
 } from '../common/types';
 import { methods } from '../methods/methods-with-executors';
 import { generate_urls } from '../common/generate-urls';
@@ -39,11 +39,11 @@ if (typeof window.content_script_state === 'undefined') { /* #226 part 1 workaro
 }
 
 async function get_method_for_url(url: string): Promise<MethodMetadataWithExecutors> {
-    if (window.prefs.activation === ActivationMode.Off) {
+    if (window.prefs.enable_policy === EnablePolicy.Off) {
         return methods[0];
     }
 
-    if (window.prefs.activation === ActivationMode['System Theme']) {
+    if (window.prefs.enable_policy === EnablePolicy['System Theme']) {
         // this disables dark mode when system is set to light theme
         if (window.matchMedia('(prefers-color-scheme:light)')) {
             return methods[0];

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -43,15 +43,6 @@ async function get_method_for_url(url: string): Promise<MethodMetadataWithExecut
         return methods[0];
     }
 
-    if (window.prefs.activation === ActivationMode['Time (6 to 6)']) {
-        const now = new Date();
-        // this disables dark mode between 6:00 and 17:59:59.
-        // FIXME: make this range configurable or even derive it from sunrise and sunset data.
-        if (now.getHours() >= 6 && now.getHours() < 18) {
-            return methods[0];
-        }
-    }
-
     if (window.prefs.activation === ActivationMode['System Theme']) {
         // this disables dark mode when system is set to light theme
         if (window.matchMedia('(prefers-color-scheme:light)')) {

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -42,6 +42,15 @@ async function get_method_for_url(url: string): Promise<MethodMetadataWithExecut
         return methods[0];
     }
 
+    if(window.prefs.night_enabled) {
+        let now = new Date();
+        // this disables dark mode between 6:00 and 18:00.
+        // FIXME: make this range configurable or even derive it from sunrise and sunset data.
+        if(now.getHours() > 6 && now.getHours() < 18){
+            return methods[0];
+        }
+    }
+
     if (is_iframe) {
         const parent_method_number = await browser.runtime.sendMessage({ action: 'query_parent_method_number' });
         if (methods[parent_method_number].affects_iframes) {

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -44,9 +44,9 @@ async function get_method_for_url(url: string): Promise<MethodMetadataWithExecut
 
     if(window.prefs.night_enabled) {
         let now = new Date();
-        // this disables dark mode between 6:00 and 18:00.
+        // this disables dark mode between 6:00 and 17:59:59.
         // FIXME: make this range configurable or even derive it from sunrise and sunset data.
-        if(now.getHours() > 6 && now.getHours() < 18){
+        if(now.getHours() >= 6 && now.getHours() < 18){
             return methods[0];
         }
     }


### PR DESCRIPTION
_Update 2_: See comment below. For usability we're down to on, off, system preference. (Most OSes include a way to toggle between dark and light mode based on time - so why replicate this in this extension?)

_Update_: See comment below. This got extended to support off, on, time (night only dark mode) and system-theme.

---
This change adds an option "Night time only". By default it is false and the current behavior remains untouched.

Setting "Night time only" to true will enable this extension just from 6PM in the evening until 6AM in the morning. During day time (6AM until 6PM) this extension is disabled. On and off times are hardcoded for now, but could definitely become a setting at one point.

Any feedback is welcome, hope this is a first good step towards solving #304.

![grafik](https://user-images.githubusercontent.com/438976/201525865-57c8cfb1-af4b-47f3-98f0-1aac084835d4.png)
